### PR TITLE
Get Google Click ID from URL and send to pixel endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## `0.7.3`
+
+Add tracking for Google Click ID
+
 ## `0.7.2`
 
 Do not trigger 2 pixels when origin domain is the same as config domain
@@ -7,7 +11,6 @@ Do not trigger 2 pixels when origin domain is the same as config domain
 ## `0.7.1`
 
 Pick custom domain from script tag data-domain attribute. This way the config is centralized.
-
 
 ## `0.7.0`
 

--- a/__tests__/pixelUrl.spec.js
+++ b/__tests__/pixelUrl.spec.js
@@ -27,4 +27,15 @@ describe('pixelUrl', () => {
         .toEqual('/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog')
     })
   })
+
+  describe('with gclid', () => {
+    it('returns the data', () => {
+      html = "<!DOCTYPE html><html lang='es'></html>"
+      dom = new JSDOM(html, {
+        url: 'https://staging.factorialhr.es/blog?gclid=123'
+      })
+      expect(pixelUrl(dom.window.document))
+        .toEqual('/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog&gclid=123')
+    })
+  })
 })

--- a/__tests__/requestParameters.spec.js
+++ b/__tests__/requestParameters.spec.js
@@ -7,11 +7,24 @@ const dom = new JSDOM(html, {
   referrer: 'https://google.com?query=cómo hacer nóminas'
 })
 
+const domWithGclid = new JSDOM(html, {
+  url: 'https://factorialhr.com/team/césar?gclid=123',
+  referrer: 'https://google.com?query=cómo hacer nóminas'
+})
+
 describe('requestParameters', () => {
   it('returns the data', () => {
     expect(requestParameters(dom.window.document)).toEqual({
       landingPage: 'https://factorialhr.com/team/c%25C3%25A9sar',
       language: 'en'
+    })
+  })
+
+  it('returns the data with gclid', () => {
+    expect(requestParameters(domWithGclid.window.document)).toEqual({
+      landingPage: 'https://factorialhr.com/team/c%25C3%25A9sar',
+      language: 'en',
+      gclid: '123'
     })
   })
 })

--- a/build/app.js
+++ b/build/app.js
@@ -121,10 +121,11 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 exports.default = function (document) {
   var _requestParameters = (0, _requestParameters3.default)(document),
       language = _requestParameters.language,
-      landingPage = _requestParameters.landingPage;
+      landingPage = _requestParameters.landingPage,
+      gclid = _requestParameters.gclid;
 
   var mc = document.location.href.match(/mc=(.*)/);
-  var attributes = ['mc=' + (mc ? mc[1] : ''), 'referer=' + encodeURI(document.referrer), 'language=' + language, 'landing_page=' + landingPage].join('&');
+  var attributes = ['mc=' + (mc ? mc[1] : ''), 'referer=' + encodeURI(document.referrer), 'language=' + language, 'landing_page=' + landingPage, 'gclid=' + gclid].join('&');
 
   return '/internal/pixel?' + attributes;
 };
@@ -141,12 +142,16 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.default = requestParameters;
 function requestParameters(document) {
-  var landing = encodeURI(document.location.href.split('?')[0]);
+  var path = document.location.origin + document.location.pathname;
+  var search = document.location.search;
+  var landing = encodeURI(path);
   var locale = document.querySelector('html').lang.split('-')[0];
+  var gclid = new URLSearchParams(search).get('gclid');
 
   return {
     language: locale,
-    landingPage: landing
+    landingPage: landing,
+    gclid: gclid
   };
 }
 

--- a/build/app.js
+++ b/build/app.js
@@ -125,9 +125,13 @@ exports.default = function (document) {
       gclid = _requestParameters.gclid;
 
   var mc = document.location.href.match(/mc=(.*)/);
-  var attributes = ['mc=' + (mc ? mc[1] : ''), 'referer=' + encodeURI(document.referrer), 'language=' + language, 'landing_page=' + landingPage, 'gclid=' + gclid].join('&');
+  var attributes = ['mc=' + (mc ? mc[1] : ''), 'referer=' + encodeURI(document.referrer), 'language=' + language, 'landing_page=' + landingPage];
 
-  return '/internal/pixel?' + attributes;
+  if (gclid) {
+    attributes.push('gclid=' + gclid);
+  }
+
+  return '/internal/pixel?' + attributes.join('&');
 };
 
 /***/ }),
@@ -140,13 +144,34 @@ exports.default = function (document) {
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+
+var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
+
 exports.default = requestParameters;
+function findPropertyInParams() {
+  var params = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
+  var property = arguments[1];
+
+  var acc = {};
+
+  params.split('&').forEach(function (param) {
+    var _param$split = param.split('='),
+        _param$split2 = _slicedToArray(_param$split, 2),
+        key = _param$split2[0],
+        value = _param$split2[1];
+
+    acc[key] = value;
+  });
+
+  return acc[property];
+}
+
 function requestParameters(document) {
   var path = document.location.origin + document.location.pathname;
-  var search = document.location.search;
+  var search = document.location.search.substring(1);
   var landing = encodeURI(path);
   var locale = document.querySelector('html').lang.split('-')[0];
-  var gclid = new URLSearchParams(search).get('gclid');
+  var gclid = findPropertyInParams(search, 'gclid');
 
   return {
     language: locale,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factorial-pixel",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Factorial marketing pixel",
   "repository": {
     "type": "git",

--- a/src/pixelUrl.js
+++ b/src/pixelUrl.js
@@ -1,13 +1,14 @@
 import requestParameters from './requestParameters'
 
 export default (document) => {
-  const { language, landingPage } = requestParameters(document)
+  const { language, landingPage, gclid } = requestParameters(document)
   const mc = document.location.href.match(/mc=(.*)/)
   const attributes = [
     `mc=${mc ? mc[1] : ''}`,
     `referer=${encodeURI(document.referrer)}`,
     `language=${language}`,
-    `landing_page=${landingPage}`
+    `landing_page=${landingPage}`,
+    `gclid=${gclid}`,
   ].join('&')
 
   return `/internal/pixel?${attributes}`

--- a/src/pixelUrl.js
+++ b/src/pixelUrl.js
@@ -7,9 +7,12 @@ export default (document) => {
     `mc=${mc ? mc[1] : ''}`,
     `referer=${encodeURI(document.referrer)}`,
     `language=${language}`,
-    `landing_page=${landingPage}`,
-    `gclid=${gclid}`,
-  ].join('&')
+    `landing_page=${landingPage}`
+  ]
 
-  return `/internal/pixel?${attributes}`
+  if (gclid) {
+    attributes.push(`gclid=${gclid}`)
+  }
+
+  return `/internal/pixel?${attributes.join('&')}`
 }

--- a/src/requestParameters.js
+++ b/src/requestParameters.js
@@ -1,20 +1,25 @@
-function findPropertyInParams(params, property) {
-  params.split('&').reduce((acc, param) => {
+function findPropertyInParams (params = '', property) {
+  const acc = {}
+
+  params.split('&').forEach((param) => {
     const [key, value] = param.split('=')
 
-    return { ...acc, [key]: value }
-  }, {})[property]
+    acc[key] = value
+  })
+
+  return acc[property]
 }
 
-export default function requestParameters(document) {
-  const [path, params] = document.location.href.split('?')
+export default function requestParameters (document) {
+  const path = document.location.origin + document.location.pathname
+  const search = document.location.search.substring(1)
   const landing = encodeURI(path)
   const locale = document.querySelector('html').lang.split('-')[0]
-  const gclid = findPropertyInParams(params, 'gclid')
+  const gclid = findPropertyInParams(search, 'gclid')
 
   return {
     language: locale,
     landingPage: landing,
-    gclid,
+    gclid
   }
 }

--- a/src/requestParameters.js
+++ b/src/requestParameters.js
@@ -1,9 +1,20 @@
-export default function requestParameters (document) {
-  const landing = encodeURI(document.location.href.split('?')[0])
+function findPropertyInParams(params, property) {
+  params.split('&').reduce((acc, param) => {
+    const [key, value] = param.split('=')
+
+    return { ...acc, [key]: value }
+  }, {})[property]
+}
+
+export default function requestParameters(document) {
+  const [path, params] = document.location.href.split('?')
+  const landing = encodeURI(path)
   const locale = document.querySelector('html').lang.split('-')[0]
+  const gclid = findPropertyInParams(params, 'gclid')
 
   return {
     language: locale,
-    landingPage: landing
+    landingPage: landing,
+    gclid,
   }
 }


### PR DESCRIPTION
# What?

We use Google Ads for paid traffic which we track from HubSpot, but we are not using 100% of the features we can get from Google Ads. If someone lands in a paid ad, it is identified by a unique Google Click Id (`gclid` in the URL), therefore this id can be used to track users that convert better and optimize paid campaign towards these user profiles.

With this information, we can reduce the CAC in paid just by sending an extra property to HubSpot and linking back to Google (done automatically from HS).

For that reason, we extract this property from the URL and send it to the pixel endpoint.

## Related PR

https://github.com/factorialco/factorial-backend/pull/13360