### PR TITLE
Fixes duplicated attribution params

### DIFF
--- a/build/app.js
+++ b/build/app.js
@@ -118,12 +118,12 @@ exports.default = function (document) {
   var _requestParameters = (0, _requestParameters3.default)(document),
       language = _requestParameters.language,
       landingPage = _requestParameters.landingPage,
+      mc = _requestParameters.mc,
       gclid = _requestParameters.gclid,
       aclid = _requestParameters.aclid,
       fbclid = _requestParameters.fbclid;
 
-  var mc = document.location.href.match(/mc=(.*)/);
-  var attributes = ['mc=' + (mc ? mc[1] : ''), 'referer=' + encodeURI(document.referrer), 'language=' + language, 'landing_page=' + landingPage];
+  var attributes = ['mc=' + (mc || ''), 'referer=' + encodeURI(document.referrer), 'language=' + language, 'landing_page=' + landingPage];
 
   if (gclid) {
     attributes.push('gclid=' + gclid);
@@ -175,6 +175,7 @@ function requestParameters(document) {
   var search = document.location.search.substring(1);
   var landing = encodeURI(path);
   var locale = document.querySelector('html').lang.split('-')[0];
+  var mc = findPropertyInParams(search, 'mc');
   var gclid = findPropertyInParams(search, 'gclid');
   var aclid = findPropertyInParams(search, 'aclid');
   var fbclid = findPropertyInParams(search, 'fbclid');
@@ -182,6 +183,7 @@ function requestParameters(document) {
   return {
     language: locale,
     landingPage: landing,
+    mc: mc,
     gclid: gclid,
     aclid: aclid,
     fbclid: fbclid

--- a/src/pixelUrl.js
+++ b/src/pixelUrl.js
@@ -1,12 +1,11 @@
 import requestParameters from './requestParameters'
 
 export default document => {
-  const { language, landingPage, gclid, aclid, fbclid } = requestParameters(
+  const { language, landingPage, mc, gclid, aclid, fbclid } = requestParameters(
     document
   )
-  const mc = document.location.href.match(/mc=(.*)/)
   const attributes = [
-    `mc=${mc ? mc[1] : ''}`,
+    `mc=${mc || ''}`,
     `referer=${encodeURI(document.referrer)}`,
     `language=${language}`,
     `landing_page=${landingPage}`

--- a/src/requestParameters.js
+++ b/src/requestParameters.js
@@ -15,7 +15,6 @@ export default function requestParameters (document) {
   const search = document.location.search.substring(1)
   const landing = encodeURI(path)
   const locale = document.querySelector('html').lang.split('-')[0]
-  
   const mc = findPropertyInParams(search, 'mc')
   const gclid = findPropertyInParams(search, 'gclid')
   const aclid = findPropertyInParams(search, 'aclid')

--- a/src/requestParameters.js
+++ b/src/requestParameters.js
@@ -15,6 +15,8 @@ export default function requestParameters (document) {
   const search = document.location.search.substring(1)
   const landing = encodeURI(path)
   const locale = document.querySelector('html').lang.split('-')[0]
+  
+  const mc = findPropertyInParams(search, 'mc')
   const gclid = findPropertyInParams(search, 'gclid')
   const aclid = findPropertyInParams(search, 'aclid')
   const fbclid = findPropertyInParams(search, 'fbclid')
@@ -22,6 +24,7 @@ export default function requestParameters (document) {
   return {
     language: locale,
     landingPage: landing,
+    mc,
     gclid,
     aclid,
     fbclid


### PR DESCRIPTION
### **What?**
Fixes bug that generated duplicated attribution params.

### **How?**
We were getting the `mc` url param incorrectly, it actually contained the whole URL after `mc=`.
This made the final URL have duplicated gclid, aclid and fbclid params (when present).
It also made the URL include any param that is included in the URL after the mc, even if we were not expecting it.

### **Wrong Regex Visualized**
![Screenshot 2025-03-21 at 16 44 24](https://github.com/user-attachments/assets/7168b37e-a500-49b6-9d72-c1a61d52d22a)

### **Before (note the extra params and the duplicated fbclid)**
![Screenshot 2025-03-21 at 16 32 33](https://github.com/user-attachments/assets/c0c9f78a-c592-4285-99cc-4b2ea4d89ab4)

### **After**
![Screenshot 2025-03-21 at 16 32 04](https://github.com/user-attachments/assets/20c3deb2-b59e-4e52-9f46-c06665fcceec)
