### PR TITLE
feat: add multi-platform click ID and placement support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## `0.10.0`
+
+Adds support for multi-platform click IDs (ttclid, li_fat_id, twclid, rdt_cid, tblci) and placement parameter.
+
 ## `0.9.0`
 
 Adds support for HubSpot Ads (HSA) parameters (hsa_ad, hsa_cam, hsa_grp, hsa_kw, hsa_mt, hsa_src, hsa_tgt).

--- a/__tests__/pixelUrl.spec.js
+++ b/__tests__/pixelUrl.spec.js
@@ -66,6 +66,78 @@ describe('pixelUrl', () => {
     })
   })
 
+  describe('with ttclid', () => {
+    it('returns the data', () => {
+      html = "<!DOCTYPE html><html lang='es'></html>"
+      dom = new JSDOM(html, {
+        url: 'https://staging.factorialhr.es/blog?ttclid=tt_123'
+      })
+      expect(pixelUrl(dom.window.document)).toEqual(
+        '/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog&ttclid=tt_123'
+      )
+    })
+  })
+
+  describe('with li_fat_id', () => {
+    it('returns the data', () => {
+      html = "<!DOCTYPE html><html lang='es'></html>"
+      dom = new JSDOM(html, {
+        url: 'https://staging.factorialhr.es/blog?li_fat_id=li_456'
+      })
+      expect(pixelUrl(dom.window.document)).toEqual(
+        '/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog&li_fat_id=li_456'
+      )
+    })
+  })
+
+  describe('with twclid', () => {
+    it('returns the data', () => {
+      html = "<!DOCTYPE html><html lang='es'></html>"
+      dom = new JSDOM(html, {
+        url: 'https://staging.factorialhr.es/blog?twclid=tw_789'
+      })
+      expect(pixelUrl(dom.window.document)).toEqual(
+        '/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog&twclid=tw_789'
+      )
+    })
+  })
+
+  describe('with rdt_cid', () => {
+    it('returns the data', () => {
+      html = "<!DOCTYPE html><html lang='es'></html>"
+      dom = new JSDOM(html, {
+        url: 'https://staging.factorialhr.es/blog?rdt_cid=rd_012'
+      })
+      expect(pixelUrl(dom.window.document)).toEqual(
+        '/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog&rdt_cid=rd_012'
+      )
+    })
+  })
+
+  describe('with tblci', () => {
+    it('returns the data', () => {
+      html = "<!DOCTYPE html><html lang='es'></html>"
+      dom = new JSDOM(html, {
+        url: 'https://staging.factorialhr.es/blog?tblci=tb_345'
+      })
+      expect(pixelUrl(dom.window.document)).toEqual(
+        '/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog&tblci=tb_345'
+      )
+    })
+  })
+
+  describe('with placement', () => {
+    it('returns the data with encoded placement', () => {
+      html = "<!DOCTYPE html><html lang='es'></html>"
+      dom = new JSDOM(html, {
+        url: 'https://staging.factorialhr.es/blog?placement=feed'
+      })
+      expect(pixelUrl(dom.window.document)).toEqual(
+        '/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog&placement=feed'
+      )
+    })
+  })
+
   describe('with UTM parameters', () => {
     it('returns the data with all UTM params', () => {
       html = "<!DOCTYPE html><html lang='en'></html>"
@@ -126,6 +198,18 @@ describe('pixelUrl', () => {
       })
       expect(pixelUrl(dom.window.document)).toEqual(
         '/internal/pixel?mc=&referer=&language=en&landing_page=https://factorialhr.com/blog&gclid=test_click_123&utm_source=google&hsa_cam=123456&hsa_src=google'
+      )
+    })
+  })
+
+  describe('with all click IDs and placement combined', () => {
+    it('includes all click IDs, UTMs, HSA, and placement', () => {
+      html = "<!DOCTYPE html><html lang='en'></html>"
+      dom = new JSDOM(html, {
+        url: 'https://factorialhr.com/blog?utm_source=tiktok&utm_medium=cpc&gclid=g_123&fbclid=fb_456&ttclid=tt_789&li_fat_id=li_012&twclid=tw_345&rdt_cid=rd_678&tblci=tb_901&hsa_cam=camp_1&placement=feed'
+      })
+      expect(pixelUrl(dom.window.document)).toEqual(
+        '/internal/pixel?mc=&referer=&language=en&landing_page=https://factorialhr.com/blog&gclid=g_123&fbclid=fb_456&ttclid=tt_789&li_fat_id=li_012&twclid=tw_345&rdt_cid=rd_678&tblci=tb_901&utm_source=tiktok&utm_medium=cpc&hsa_cam=camp_1&placement=feed'
       )
     })
   })

--- a/__tests__/requestParameters.spec.js
+++ b/__tests__/requestParameters.spec.js
@@ -32,6 +32,36 @@ const domWithHsa = new JSDOM(html, {
   referrer: 'https://google.com?query=cómo hacer nóminas'
 })
 
+const domWithTtclid = new JSDOM(html, {
+  url: 'https://factorialhr.com/team/césar?ttclid=tt_click_123',
+  referrer: 'https://google.com?query=cómo hacer nóminas'
+})
+
+const domWithLiFatId = new JSDOM(html, {
+  url: 'https://factorialhr.com/team/césar?li_fat_id=li_click_456',
+  referrer: 'https://google.com?query=cómo hacer nóminas'
+})
+
+const domWithTwclid = new JSDOM(html, {
+  url: 'https://factorialhr.com/team/césar?twclid=tw_click_789',
+  referrer: 'https://google.com?query=cómo hacer nóminas'
+})
+
+const domWithRdtCid = new JSDOM(html, {
+  url: 'https://factorialhr.com/team/césar?rdt_cid=rd_click_012',
+  referrer: 'https://google.com?query=cómo hacer nóminas'
+})
+
+const domWithTblci = new JSDOM(html, {
+  url: 'https://factorialhr.com/team/césar?tblci=tb_click_345',
+  referrer: 'https://google.com?query=cómo hacer nóminas'
+})
+
+const domWithPlacement = new JSDOM(html, {
+  url: 'https://factorialhr.com/team/césar?placement=feed',
+  referrer: 'https://google.com?query=cómo hacer nóminas'
+})
+
 describe('requestParameters', () => {
   it('returns the data', () => {
     expect(requestParameters(dom.window.document)).toEqual({
@@ -87,6 +117,54 @@ describe('requestParameters', () => {
       hsa_mt: 'exact',
       hsa_src: 'google',
       hsa_tgt: '901234'
+    })
+  })
+
+  it('returns the data with ttclid', () => {
+    expect(requestParameters(domWithTtclid.window.document)).toEqual({
+      landingPage: 'https://factorialhr.com/team/c%25C3%25A9sar',
+      language: 'en',
+      ttclid: 'tt_click_123'
+    })
+  })
+
+  it('returns the data with li_fat_id', () => {
+    expect(requestParameters(domWithLiFatId.window.document)).toEqual({
+      landingPage: 'https://factorialhr.com/team/c%25C3%25A9sar',
+      language: 'en',
+      li_fat_id: 'li_click_456'
+    })
+  })
+
+  it('returns the data with twclid', () => {
+    expect(requestParameters(domWithTwclid.window.document)).toEqual({
+      landingPage: 'https://factorialhr.com/team/c%25C3%25A9sar',
+      language: 'en',
+      twclid: 'tw_click_789'
+    })
+  })
+
+  it('returns the data with rdt_cid', () => {
+    expect(requestParameters(domWithRdtCid.window.document)).toEqual({
+      landingPage: 'https://factorialhr.com/team/c%25C3%25A9sar',
+      language: 'en',
+      rdt_cid: 'rd_click_012'
+    })
+  })
+
+  it('returns the data with tblci', () => {
+    expect(requestParameters(domWithTblci.window.document)).toEqual({
+      landingPage: 'https://factorialhr.com/team/c%25C3%25A9sar',
+      language: 'en',
+      tblci: 'tb_click_345'
+    })
+  })
+
+  it('returns the data with placement', () => {
+    expect(requestParameters(domWithPlacement.window.document)).toEqual({
+      landingPage: 'https://factorialhr.com/team/c%25C3%25A9sar',
+      language: 'en',
+      placement: 'feed'
     })
   })
 })

--- a/build/app.js
+++ b/build/app.js
@@ -122,6 +122,11 @@ exports.default = function (document) {
       gclid = _requestParameters.gclid,
       aclid = _requestParameters.aclid,
       fbclid = _requestParameters.fbclid,
+      ttclid = _requestParameters.ttclid,
+      li_fat_id = _requestParameters.li_fat_id,
+      twclid = _requestParameters.twclid,
+      rdt_cid = _requestParameters.rdt_cid,
+      tblci = _requestParameters.tblci,
       utm_source = _requestParameters.utm_source,
       utm_medium = _requestParameters.utm_medium,
       utm_campaign = _requestParameters.utm_campaign,
@@ -133,7 +138,8 @@ exports.default = function (document) {
       hsa_kw = _requestParameters.hsa_kw,
       hsa_mt = _requestParameters.hsa_mt,
       hsa_src = _requestParameters.hsa_src,
-      hsa_tgt = _requestParameters.hsa_tgt;
+      hsa_tgt = _requestParameters.hsa_tgt,
+      placement = _requestParameters.placement;
 
   var attributes = ['mc=' + (mc || ''), 'referer=' + encodeURI(document.referrer), 'language=' + language, 'landing_page=' + landingPage];
 
@@ -145,6 +151,21 @@ exports.default = function (document) {
   }
   if (fbclid) {
     attributes.push('fbclid=' + fbclid);
+  }
+  if (ttclid) {
+    attributes.push('ttclid=' + ttclid);
+  }
+  if (li_fat_id) {
+    attributes.push('li_fat_id=' + li_fat_id);
+  }
+  if (twclid) {
+    attributes.push('twclid=' + twclid);
+  }
+  if (rdt_cid) {
+    attributes.push('rdt_cid=' + rdt_cid);
+  }
+  if (tblci) {
+    attributes.push('tblci=' + tblci);
   }
   if (utm_source) {
     attributes.push('utm_source=' + encodeURIComponent(utm_source));
@@ -181,6 +202,9 @@ exports.default = function (document) {
   }
   if (hsa_tgt) {
     attributes.push('hsa_tgt=' + encodeURIComponent(hsa_tgt));
+  }
+  if (placement) {
+    attributes.push('placement=' + encodeURIComponent(placement));
   }
 
   return '/internal/pixel?' + attributes.join('&');
@@ -239,6 +263,12 @@ function requestParameters(document) {
   var hsa_mt = findPropertyInParams(search, 'hsa_mt');
   var hsa_src = findPropertyInParams(search, 'hsa_src');
   var hsa_tgt = findPropertyInParams(search, 'hsa_tgt');
+  var ttclid = findPropertyInParams(search, 'ttclid');
+  var li_fat_id = findPropertyInParams(search, 'li_fat_id');
+  var twclid = findPropertyInParams(search, 'twclid');
+  var rdt_cid = findPropertyInParams(search, 'rdt_cid');
+  var tblci = findPropertyInParams(search, 'tblci');
+  var placement = findPropertyInParams(search, 'placement');
 
   return {
     language: locale,
@@ -247,6 +277,11 @@ function requestParameters(document) {
     gclid: gclid,
     aclid: aclid,
     fbclid: fbclid,
+    ttclid: ttclid,
+    li_fat_id: li_fat_id,
+    twclid: twclid,
+    rdt_cid: rdt_cid,
+    tblci: tblci,
     utm_source: utm_source,
     utm_medium: utm_medium,
     utm_campaign: utm_campaign,
@@ -258,7 +293,8 @@ function requestParameters(document) {
     hsa_kw: hsa_kw,
     hsa_mt: hsa_mt,
     hsa_src: hsa_src,
-    hsa_tgt: hsa_tgt
+    hsa_tgt: hsa_tgt,
+    placement: placement
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factorial-pixel",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Factorial marketing pixel",
   "repository": {
     "type": "git",

--- a/src/pixelUrl.js
+++ b/src/pixelUrl.js
@@ -1,7 +1,7 @@
 import requestParameters from './requestParameters'
 
 export default document => {
-  const { language, landingPage, mc, gclid, aclid, fbclid, utm_source, utm_medium, utm_campaign, utm_content, utm_term, hsa_ad, hsa_cam, hsa_grp, hsa_kw, hsa_mt, hsa_src, hsa_tgt } = requestParameters(
+  const { language, landingPage, mc, gclid, aclid, fbclid, ttclid, li_fat_id, twclid, rdt_cid, tblci, utm_source, utm_medium, utm_campaign, utm_content, utm_term, hsa_ad, hsa_cam, hsa_grp, hsa_kw, hsa_mt, hsa_src, hsa_tgt, placement } = requestParameters(
     document
   )
   const attributes = [
@@ -19,6 +19,21 @@ export default document => {
   }
   if (fbclid) {
     attributes.push(`fbclid=${fbclid}`)
+  }
+  if (ttclid) {
+    attributes.push(`ttclid=${ttclid}`)
+  }
+  if (li_fat_id) {
+    attributes.push(`li_fat_id=${li_fat_id}`)
+  }
+  if (twclid) {
+    attributes.push(`twclid=${twclid}`)
+  }
+  if (rdt_cid) {
+    attributes.push(`rdt_cid=${rdt_cid}`)
+  }
+  if (tblci) {
+    attributes.push(`tblci=${tblci}`)
   }
   if (utm_source) {
     attributes.push(`utm_source=${encodeURIComponent(utm_source)}`)
@@ -55,6 +70,9 @@ export default document => {
   }
   if (hsa_tgt) {
     attributes.push(`hsa_tgt=${encodeURIComponent(hsa_tgt)}`)
+  }
+  if (placement) {
+    attributes.push(`placement=${encodeURIComponent(placement)}`)
   }
 
   return `/internal/pixel?${attributes.join('&')}`

--- a/src/requestParameters.js
+++ b/src/requestParameters.js
@@ -31,6 +31,12 @@ export default function requestParameters (document) {
   const hsa_mt = findPropertyInParams(search, 'hsa_mt')
   const hsa_src = findPropertyInParams(search, 'hsa_src')
   const hsa_tgt = findPropertyInParams(search, 'hsa_tgt')
+  const ttclid = findPropertyInParams(search, 'ttclid')
+  const li_fat_id = findPropertyInParams(search, 'li_fat_id')
+  const twclid = findPropertyInParams(search, 'twclid')
+  const rdt_cid = findPropertyInParams(search, 'rdt_cid')
+  const tblci = findPropertyInParams(search, 'tblci')
+  const placement = findPropertyInParams(search, 'placement')
 
   return {
     language: locale,
@@ -39,6 +45,11 @@ export default function requestParameters (document) {
     gclid,
     aclid,
     fbclid,
+    ttclid,
+    li_fat_id,
+    twclid,
+    rdt_cid,
+    tblci,
     utm_source,
     utm_medium,
     utm_campaign,
@@ -50,6 +61,7 @@ export default function requestParameters (document) {
     hsa_kw,
     hsa_mt,
     hsa_src,
-    hsa_tgt
+    hsa_tgt,
+    placement
   }
 }


### PR DESCRIPTION
## 🚪 Why?

Extend attribution tracking to capture click IDs from TikTok, LinkedIn, Twitter/X, Reddit, and Taboola, plus a `placement` parameter for ad platform info.

## 🔑 What?

- Extract and send 5 new click IDs (`ttclid`, `li_fat_id`, `twclid`, `rdt_cid`, `tblci`) from URL to pixel endpoint
- Extract and send `placement` parameter (URL-encoded, free-text)
- Version bump to `0.10.0`

## 🏡 Context
- https://github.com/factorialco/factorial/pull/92663
- https://github.com/factorialco/factorial/pull/92664
- [📊 Paid Tracking Mapping](https://docs.google.com/spreadsheets/d/1_GBsPLXRUoECL6nu6eDY-5PzxQ_oOWUududyyQsLW2k/edit?gid=1790738376#gid=1790738376)