### PR TITLE
feat(colab): add support for colab_name in pixel URL and request para…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## `0.11.0`
+
+Adds support for colab_name parameter.
+
+
 ## `0.10.0`
 
 Adds support for multi-platform click IDs (ttclid, li_fat_id, twclid, rdt_cid, tblci) and placement parameter.

--- a/__tests__/pixelUrl.spec.js
+++ b/__tests__/pixelUrl.spec.js
@@ -202,6 +202,18 @@ describe('pixelUrl', () => {
     })
   })
 
+  describe('with colab_name', () => {
+    it('returns the data', () => {
+      html = "<!DOCTYPE html><html lang='es'></html>"
+      dom = new JSDOM(html, {
+        url: 'https://staging.factorialhr.es/blog?colab_name=my_colab'
+      })
+      expect(pixelUrl(dom.window.document)).toEqual(
+        '/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog&colab_name=my_colab'
+      )
+    })
+  })
+
   describe('with all click IDs and placement combined', () => {
     it('includes all click IDs, UTMs, HSA, and placement', () => {
       html = "<!DOCTYPE html><html lang='en'></html>"

--- a/__tests__/requestParameters.spec.js
+++ b/__tests__/requestParameters.spec.js
@@ -62,6 +62,11 @@ const domWithPlacement = new JSDOM(html, {
   referrer: 'https://google.com?query=cómo hacer nóminas'
 })
 
+const domWithColabName = new JSDOM(html, {
+  url: 'https://factorialhr.com/team/césar?colab_name=my_colab',
+  referrer: 'https://google.com?query=cómo hacer nóminas'
+})
+
 describe('requestParameters', () => {
   it('returns the data', () => {
     expect(requestParameters(dom.window.document)).toEqual({
@@ -165,6 +170,14 @@ describe('requestParameters', () => {
       landingPage: 'https://factorialhr.com/team/c%25C3%25A9sar',
       language: 'en',
       placement: 'feed'
+    })
+  })
+
+  it('returns the data with colab_name', () => {
+    expect(requestParameters(domWithColabName.window.document)).toEqual({
+      landingPage: 'https://factorialhr.com/team/c%25C3%25A9sar',
+      language: 'en',
+      colab_name: 'my_colab'
     })
   })
 })

--- a/build/app.js
+++ b/build/app.js
@@ -139,7 +139,8 @@ exports.default = function (document) {
       hsa_mt = _requestParameters.hsa_mt,
       hsa_src = _requestParameters.hsa_src,
       hsa_tgt = _requestParameters.hsa_tgt,
-      placement = _requestParameters.placement;
+      placement = _requestParameters.placement,
+      colab_name = _requestParameters.colab_name;
 
   var attributes = ['mc=' + (mc || ''), 'referer=' + encodeURI(document.referrer), 'language=' + language, 'landing_page=' + landingPage];
 
@@ -206,6 +207,9 @@ exports.default = function (document) {
   if (placement) {
     attributes.push('placement=' + encodeURIComponent(placement));
   }
+  if (colab_name) {
+    attributes.push('colab_name=' + encodeURIComponent(colab_name));
+  }
 
   return '/internal/pixel?' + attributes.join('&');
 };
@@ -269,6 +273,7 @@ function requestParameters(document) {
   var rdt_cid = findPropertyInParams(search, 'rdt_cid');
   var tblci = findPropertyInParams(search, 'tblci');
   var placement = findPropertyInParams(search, 'placement');
+  var colab_name = findPropertyInParams(search, 'colab_name');
 
   return {
     language: locale,
@@ -294,7 +299,8 @@ function requestParameters(document) {
     hsa_mt: hsa_mt,
     hsa_src: hsa_src,
     hsa_tgt: hsa_tgt,
-    placement: placement
+    placement: placement,
+    colab_name: colab_name
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "factorial-pixel",
-  "version": "0.9.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "factorial-pixel",
-      "version": "0.9.0",
+      "version": "0.11.0",
       "license": "MIT",
       "devDependencies": {
         "babel-cli": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factorial-pixel",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Factorial marketing pixel",
   "repository": {
     "type": "git",

--- a/src/pixelUrl.js
+++ b/src/pixelUrl.js
@@ -1,7 +1,7 @@
 import requestParameters from './requestParameters'
 
 export default document => {
-  const { language, landingPage, mc, gclid, aclid, fbclid, ttclid, li_fat_id, twclid, rdt_cid, tblci, utm_source, utm_medium, utm_campaign, utm_content, utm_term, hsa_ad, hsa_cam, hsa_grp, hsa_kw, hsa_mt, hsa_src, hsa_tgt, placement } = requestParameters(
+  const { language, landingPage, mc, gclid, aclid, fbclid, ttclid, li_fat_id, twclid, rdt_cid, tblci, utm_source, utm_medium, utm_campaign, utm_content, utm_term, hsa_ad, hsa_cam, hsa_grp, hsa_kw, hsa_mt, hsa_src, hsa_tgt, placement, colab_name } = requestParameters(
     document
   )
   const attributes = [
@@ -73,6 +73,9 @@ export default document => {
   }
   if (placement) {
     attributes.push(`placement=${encodeURIComponent(placement)}`)
+  }
+  if (colab_name) {
+    attributes.push(`colab_name=${encodeURIComponent(colab_name)}`)
   }
 
   return `/internal/pixel?${attributes.join('&')}`

--- a/src/requestParameters.js
+++ b/src/requestParameters.js
@@ -37,6 +37,7 @@ export default function requestParameters (document) {
   const rdt_cid = findPropertyInParams(search, 'rdt_cid')
   const tblci = findPropertyInParams(search, 'tblci')
   const placement = findPropertyInParams(search, 'placement')
+  const colab_name = findPropertyInParams(search, 'colab_name')
 
   return {
     language: locale,
@@ -62,6 +63,7 @@ export default function requestParameters (document) {
     hsa_mt,
     hsa_src,
     hsa_tgt,
-    placement
+    placement,
+    colab_name
   }
 }


### PR DESCRIPTION
## 🚪 Why?

The pixel needs to capture and forward the `colab_name` URL parameter to the backend.

## 🔑 What?

- Added `colab_name` to the list of URL parameters parsed in `requestParameters.js`
- Added `colab_name` to the attributes sent in the pixel URL in `pixelUrl.js`
- Added tests for both `requestParameters` and `pixelUrl` covering the new parameter

## 🏡 Context

- [💼 Jira](https://factorialmakers.atlassian.net/browse/GM-30?atlOrigin=eyJpIjoiZGVhZTUzOTE3MjkwNDJiNjg1MTg2YzIwMWM5MWE1ZGIiLCJwIjoiaiJ9)
- [💻 Other PR](https://github.com/factorialco/factorial/pull/99285)
