### PR TITLE
Migrate to ATTRIBUTION cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
+## `0.12.0`
+
+Drop `mc` support. Attribute to "/api/attribution/pixel" endpoint. See https://app.notion.com/p/factorialco/Attribution-wire-attribution-into-the-HubSpot-contact-sync-38f5e6e051ee8137826efe9a4f54ccfd
+
 ## `0.11.0`
 
 Adds support for colab_name parameter.
-
 
 ## `0.10.0`
 

--- a/__tests__/pixelUrl.spec.js
+++ b/__tests__/pixelUrl.spec.js
@@ -13,7 +13,7 @@ describe('pixelUrl', () => {
         referrer: 'https://google.com?query=cómo hacer nóminas'
       })
       expect(pixelUrl(dom.window.document)).toEqual(
-        '/internal/pixel?mc=123&referer=https://google.com/?query=c%25C3%25B3mo%2520hacer%2520n%25C3%25B3minas&language=en&landing_page=https://factorialhr.com/blog'
+        '/attribution/pixel?referer=https://google.com/?query=c%25C3%25B3mo%2520hacer%2520n%25C3%25B3minas&language=en&landing_page=https://factorialhr.com/blog'
       )
     })
   })
@@ -25,7 +25,7 @@ describe('pixelUrl', () => {
         url: 'https://staging.factorialhr.es/blog'
       })
       expect(pixelUrl(dom.window.document)).toEqual(
-        '/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog'
+        '/attribution/pixel?referer=&language=es&landing_page=https://staging.factorialhr.es/blog'
       )
     })
   })
@@ -37,7 +37,7 @@ describe('pixelUrl', () => {
         url: 'https://staging.factorialhr.es/blog?gclid=123'
       })
       expect(pixelUrl(dom.window.document)).toEqual(
-        '/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog&gclid=123'
+        '/attribution/pixel?referer=&language=es&landing_page=https://staging.factorialhr.es/blog&gclid=123'
       )
     })
   })
@@ -49,7 +49,7 @@ describe('pixelUrl', () => {
         url: 'https://staging.factorialhr.es/blog?aclid=123'
       })
       expect(pixelUrl(dom.window.document)).toEqual(
-        '/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog&aclid=123'
+        '/attribution/pixel?referer=&language=es&landing_page=https://staging.factorialhr.es/blog&aclid=123'
       )
     })
   })
@@ -61,7 +61,7 @@ describe('pixelUrl', () => {
         url: 'https://staging.factorialhr.es/blog?fbclid=123'
       })
       expect(pixelUrl(dom.window.document)).toEqual(
-        '/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog&fbclid=123'
+        '/attribution/pixel?referer=&language=es&landing_page=https://staging.factorialhr.es/blog&fbclid=123'
       )
     })
   })
@@ -73,7 +73,7 @@ describe('pixelUrl', () => {
         url: 'https://staging.factorialhr.es/blog?ttclid=tt_123'
       })
       expect(pixelUrl(dom.window.document)).toEqual(
-        '/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog&ttclid=tt_123'
+        '/attribution/pixel?referer=&language=es&landing_page=https://staging.factorialhr.es/blog&ttclid=tt_123'
       )
     })
   })
@@ -85,7 +85,7 @@ describe('pixelUrl', () => {
         url: 'https://staging.factorialhr.es/blog?li_fat_id=li_456'
       })
       expect(pixelUrl(dom.window.document)).toEqual(
-        '/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog&li_fat_id=li_456'
+        '/attribution/pixel?referer=&language=es&landing_page=https://staging.factorialhr.es/blog&li_fat_id=li_456'
       )
     })
   })
@@ -97,7 +97,7 @@ describe('pixelUrl', () => {
         url: 'https://staging.factorialhr.es/blog?twclid=tw_789'
       })
       expect(pixelUrl(dom.window.document)).toEqual(
-        '/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog&twclid=tw_789'
+        '/attribution/pixel?referer=&language=es&landing_page=https://staging.factorialhr.es/blog&twclid=tw_789'
       )
     })
   })
@@ -109,7 +109,7 @@ describe('pixelUrl', () => {
         url: 'https://staging.factorialhr.es/blog?rdt_cid=rd_012'
       })
       expect(pixelUrl(dom.window.document)).toEqual(
-        '/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog&rdt_cid=rd_012'
+        '/attribution/pixel?referer=&language=es&landing_page=https://staging.factorialhr.es/blog&rdt_cid=rd_012'
       )
     })
   })
@@ -121,7 +121,7 @@ describe('pixelUrl', () => {
         url: 'https://staging.factorialhr.es/blog?tblci=tb_345'
       })
       expect(pixelUrl(dom.window.document)).toEqual(
-        '/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog&tblci=tb_345'
+        '/attribution/pixel?referer=&language=es&landing_page=https://staging.factorialhr.es/blog&tblci=tb_345'
       )
     })
   })
@@ -133,7 +133,7 @@ describe('pixelUrl', () => {
         url: 'https://staging.factorialhr.es/blog?placement=feed'
       })
       expect(pixelUrl(dom.window.document)).toEqual(
-        '/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog&placement=feed'
+        '/attribution/pixel?referer=&language=es&landing_page=https://staging.factorialhr.es/blog&placement=feed'
       )
     })
   })
@@ -142,30 +142,33 @@ describe('pixelUrl', () => {
     it('returns the data with all UTM params', () => {
       html = "<!DOCTYPE html><html lang='en'></html>"
       dom = new JSDOM(html, {
-        url: 'https://factorialhr.com/blog?utm_source=google&utm_medium=cpc&utm_campaign=Q1_Brand&utm_content=ad_1&utm_term=hr_software'
+        url:
+          'https://factorialhr.com/blog?utm_source=google&utm_medium=cpc&utm_campaign=Q1_Brand&utm_content=ad_1&utm_term=hr_software'
       })
       expect(pixelUrl(dom.window.document)).toEqual(
-        '/internal/pixel?mc=&referer=&language=en&landing_page=https://factorialhr.com/blog&utm_source=google&utm_medium=cpc&utm_campaign=Q1_Brand&utm_content=ad_1&utm_term=hr_software'
+        '/attribution/pixel?referer=&language=en&landing_page=https://factorialhr.com/blog&utm_source=google&utm_medium=cpc&utm_campaign=Q1_Brand&utm_content=ad_1&utm_term=hr_software'
       )
     })
 
     it('encodes UTM parameters with special characters', () => {
       html = "<!DOCTYPE html><html lang='en'></html>"
       dom = new JSDOM(html, {
-        url: 'https://factorialhr.com/blog?utm_source=google&utm_campaign=Q1%20Brand%20Campaign&utm_content=ad%20%231'
+        url:
+          'https://factorialhr.com/blog?utm_source=google&utm_campaign=Q1%20Brand%20Campaign&utm_content=ad%20%231'
       })
       expect(pixelUrl(dom.window.document)).toEqual(
-        '/internal/pixel?mc=&referer=&language=en&landing_page=https://factorialhr.com/blog&utm_source=google&utm_campaign=Q1%2520Brand%2520Campaign&utm_content=ad%2520%25231'
+        '/attribution/pixel?referer=&language=en&landing_page=https://factorialhr.com/blog&utm_source=google&utm_campaign=Q1%2520Brand%2520Campaign&utm_content=ad%2520%25231'
       )
     })
 
     it('combines UTMs with gclid', () => {
       html = "<!DOCTYPE html><html lang='en'></html>"
       dom = new JSDOM(html, {
-        url: 'https://factorialhr.com/blog?utm_source=google&utm_medium=cpc&utm_campaign=Q1&gclid=test_click_123'
+        url:
+          'https://factorialhr.com/blog?utm_source=google&utm_medium=cpc&utm_campaign=Q1&gclid=test_click_123'
       })
       expect(pixelUrl(dom.window.document)).toEqual(
-        '/internal/pixel?mc=&referer=&language=en&landing_page=https://factorialhr.com/blog&gclid=test_click_123&utm_source=google&utm_medium=cpc&utm_campaign=Q1'
+        '/attribution/pixel?referer=&language=en&landing_page=https://factorialhr.com/blog&gclid=test_click_123&utm_source=google&utm_medium=cpc&utm_campaign=Q1'
       )
     })
   })
@@ -174,30 +177,33 @@ describe('pixelUrl', () => {
     it('returns the data with all HSA params', () => {
       html = "<!DOCTYPE html><html lang='en'></html>"
       dom = new JSDOM(html, {
-        url: 'https://factorialhr.com/blog?hsa_cam=123456&hsa_grp=789012&hsa_ad=345678&hsa_src=google&hsa_mt=exact&hsa_kw=hr_software&hsa_tgt=901234'
+        url:
+          'https://factorialhr.com/blog?hsa_cam=123456&hsa_grp=789012&hsa_ad=345678&hsa_src=google&hsa_mt=exact&hsa_kw=hr_software&hsa_tgt=901234'
       })
       expect(pixelUrl(dom.window.document)).toEqual(
-        '/internal/pixel?mc=&referer=&language=en&landing_page=https://factorialhr.com/blog&hsa_ad=345678&hsa_cam=123456&hsa_grp=789012&hsa_kw=hr_software&hsa_mt=exact&hsa_src=google&hsa_tgt=901234'
+        '/attribution/pixel?referer=&language=en&landing_page=https://factorialhr.com/blog&hsa_ad=345678&hsa_cam=123456&hsa_grp=789012&hsa_kw=hr_software&hsa_mt=exact&hsa_src=google&hsa_tgt=901234'
       )
     })
 
     it('encodes HSA parameters with special characters', () => {
       html = "<!DOCTYPE html><html lang='en'></html>"
       dom = new JSDOM(html, {
-        url: 'https://factorialhr.com/blog?hsa_cam=123&hsa_kw=hr%20software%20%23best'
+        url:
+          'https://factorialhr.com/blog?hsa_cam=123&hsa_kw=hr%20software%20%23best'
       })
       expect(pixelUrl(dom.window.document)).toEqual(
-        '/internal/pixel?mc=&referer=&language=en&landing_page=https://factorialhr.com/blog&hsa_cam=123&hsa_kw=hr%2520software%2520%2523best'
+        '/attribution/pixel?referer=&language=en&landing_page=https://factorialhr.com/blog&hsa_cam=123&hsa_kw=hr%2520software%2520%2523best'
       )
     })
 
     it('combines HSA with UTM and gclid parameters', () => {
       html = "<!DOCTYPE html><html lang='en'></html>"
       dom = new JSDOM(html, {
-        url: 'https://factorialhr.com/blog?utm_source=google&hsa_cam=123456&hsa_src=google&gclid=test_click_123'
+        url:
+          'https://factorialhr.com/blog?utm_source=google&hsa_cam=123456&hsa_src=google&gclid=test_click_123'
       })
       expect(pixelUrl(dom.window.document)).toEqual(
-        '/internal/pixel?mc=&referer=&language=en&landing_page=https://factorialhr.com/blog&gclid=test_click_123&utm_source=google&hsa_cam=123456&hsa_src=google'
+        '/attribution/pixel?referer=&language=en&landing_page=https://factorialhr.com/blog&gclid=test_click_123&utm_source=google&hsa_cam=123456&hsa_src=google'
       )
     })
   })
@@ -209,7 +215,7 @@ describe('pixelUrl', () => {
         url: 'https://staging.factorialhr.es/blog?colab_name=my_colab'
       })
       expect(pixelUrl(dom.window.document)).toEqual(
-        '/internal/pixel?mc=&referer=&language=es&landing_page=https://staging.factorialhr.es/blog&colab_name=my_colab'
+        '/attribution/pixel?referer=&language=es&landing_page=https://staging.factorialhr.es/blog&colab_name=my_colab'
       )
     })
   })
@@ -218,10 +224,11 @@ describe('pixelUrl', () => {
     it('includes all click IDs, UTMs, HSA, and placement', () => {
       html = "<!DOCTYPE html><html lang='en'></html>"
       dom = new JSDOM(html, {
-        url: 'https://factorialhr.com/blog?utm_source=tiktok&utm_medium=cpc&gclid=g_123&fbclid=fb_456&ttclid=tt_789&li_fat_id=li_012&twclid=tw_345&rdt_cid=rd_678&tblci=tb_901&hsa_cam=camp_1&placement=feed'
+        url:
+          'https://factorialhr.com/blog?utm_source=tiktok&utm_medium=cpc&gclid=g_123&fbclid=fb_456&ttclid=tt_789&li_fat_id=li_012&twclid=tw_345&rdt_cid=rd_678&tblci=tb_901&hsa_cam=camp_1&placement=feed'
       })
       expect(pixelUrl(dom.window.document)).toEqual(
-        '/internal/pixel?mc=&referer=&language=en&landing_page=https://factorialhr.com/blog&gclid=g_123&fbclid=fb_456&ttclid=tt_789&li_fat_id=li_012&twclid=tw_345&rdt_cid=rd_678&tblci=tb_901&utm_source=tiktok&utm_medium=cpc&hsa_cam=camp_1&placement=feed'
+        '/attribution/pixel?referer=&language=en&landing_page=https://factorialhr.com/blog&gclid=g_123&fbclid=fb_456&ttclid=tt_789&li_fat_id=li_012&twclid=tw_345&rdt_cid=rd_678&tblci=tb_901&utm_source=tiktok&utm_medium=cpc&hsa_cam=camp_1&placement=feed'
       )
     })
   })

--- a/__tests__/requestParameters.spec.js
+++ b/__tests__/requestParameters.spec.js
@@ -23,12 +23,14 @@ const domWithFbclid = new JSDOM(html, {
 })
 
 const domWithUtms = new JSDOM(html, {
-  url: 'https://factorialhr.com/team/césar?utm_source=google&utm_medium=cpc&utm_campaign=Q1_Brand&utm_content=ad_variant_1&utm_term=hr_software',
+  url:
+    'https://factorialhr.com/team/césar?utm_source=google&utm_medium=cpc&utm_campaign=Q1_Brand&utm_content=ad_variant_1&utm_term=hr_software',
   referrer: 'https://google.com?query=cómo hacer nóminas'
 })
 
 const domWithHsa = new JSDOM(html, {
-  url: 'https://factorialhr.com/team/césar?hsa_cam=123456&hsa_grp=789012&hsa_ad=345678&hsa_src=google&hsa_mt=exact&hsa_kw=hr_software&hsa_tgt=901234',
+  url:
+    'https://factorialhr.com/team/césar?hsa_cam=123456&hsa_grp=789012&hsa_ad=345678&hsa_src=google&hsa_mt=exact&hsa_kw=hr_software&hsa_tgt=901234',
   referrer: 'https://google.com?query=cómo hacer nóminas'
 })
 

--- a/build/app.js
+++ b/build/app.js
@@ -88,7 +88,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 var script = document.getElementById('factorial-pixel');
 var customDomain = script ? script.getAttribute('data-domain') : null;
-var domain = customDomain || 'https://api.factorialhr.com';
+var domain = customDomain || 'https://factorialhr.com/api';
 
 var img = document.createElement('img');
 img.src = '' + domain + (0, _pixelUrl2.default)(document);
@@ -118,7 +118,6 @@ exports.default = function (document) {
   var _requestParameters = (0, _requestParameters3.default)(document),
       language = _requestParameters.language,
       landingPage = _requestParameters.landingPage,
-      mc = _requestParameters.mc,
       gclid = _requestParameters.gclid,
       aclid = _requestParameters.aclid,
       fbclid = _requestParameters.fbclid,
@@ -142,7 +141,7 @@ exports.default = function (document) {
       placement = _requestParameters.placement,
       colab_name = _requestParameters.colab_name;
 
-  var attributes = ['mc=' + (mc || ''), 'referer=' + encodeURI(document.referrer), 'language=' + language, 'landing_page=' + landingPage];
+  var attributes = ['referer=' + encodeURI(document.referrer), 'language=' + language, 'landing_page=' + landingPage];
 
   if (gclid) {
     attributes.push('gclid=' + gclid);
@@ -211,7 +210,7 @@ exports.default = function (document) {
     attributes.push('colab_name=' + encodeURIComponent(colab_name));
   }
 
-  return '/internal/pixel?' + attributes.join('&');
+  return '/attribution/pixel?' + attributes.join('&');
 };
 
 /***/ }),
@@ -251,7 +250,6 @@ function requestParameters(document) {
   var search = document.location.search.substring(1);
   var landing = encodeURI(path);
   var locale = document.querySelector('html').lang.split('-')[0];
-  var mc = findPropertyInParams(search, 'mc');
   var gclid = findPropertyInParams(search, 'gclid');
   var aclid = findPropertyInParams(search, 'aclid');
   var fbclid = findPropertyInParams(search, 'fbclid');
@@ -278,7 +276,6 @@ function requestParameters(document) {
   return {
     language: locale,
     landingPage: landing,
-    mc: mc,
     gclid: gclid,
     aclid: aclid,
     fbclid: fbclid,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factorial-pixel",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Factorial marketing pixel",
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import pixelUrl from './pixelUrl'
 
 const script = document.getElementById('factorial-pixel')
 const customDomain = script ? script.getAttribute('data-domain') : null
-const domain = customDomain || 'https://api.factorialhr.com'
+const domain = customDomain || 'https://factorialhr.com/api'
 
 const img = document.createElement('img')
 img.src = `${domain}${pixelUrl(document)}`

--- a/src/pixelUrl.js
+++ b/src/pixelUrl.js
@@ -1,9 +1,32 @@
 import requestParameters from './requestParameters'
 
 export default document => {
-  const { language, landingPage, gclid, aclid, fbclid, ttclid, li_fat_id, twclid, rdt_cid, tblci, utm_source, utm_medium, utm_campaign, utm_content, utm_term, hsa_ad, hsa_cam, hsa_grp, hsa_kw, hsa_mt, hsa_src, hsa_tgt, placement, colab_name } = requestParameters(
-    document
-  )
+  const {
+    language,
+    landingPage,
+    gclid,
+    aclid,
+    fbclid,
+    ttclid,
+    li_fat_id,
+    twclid,
+    rdt_cid,
+    tblci,
+    utm_source,
+    utm_medium,
+    utm_campaign,
+    utm_content,
+    utm_term,
+    hsa_ad,
+    hsa_cam,
+    hsa_grp,
+    hsa_kw,
+    hsa_mt,
+    hsa_src,
+    hsa_tgt,
+    placement,
+    colab_name
+  } = requestParameters(document)
   const attributes = [
     `referer=${encodeURI(document.referrer)}`,
     `language=${language}`,

--- a/src/pixelUrl.js
+++ b/src/pixelUrl.js
@@ -1,11 +1,10 @@
 import requestParameters from './requestParameters'
 
 export default document => {
-  const { language, landingPage, mc, gclid, aclid, fbclid, ttclid, li_fat_id, twclid, rdt_cid, tblci, utm_source, utm_medium, utm_campaign, utm_content, utm_term, hsa_ad, hsa_cam, hsa_grp, hsa_kw, hsa_mt, hsa_src, hsa_tgt, placement, colab_name } = requestParameters(
+  const { language, landingPage, gclid, aclid, fbclid, ttclid, li_fat_id, twclid, rdt_cid, tblci, utm_source, utm_medium, utm_campaign, utm_content, utm_term, hsa_ad, hsa_cam, hsa_grp, hsa_kw, hsa_mt, hsa_src, hsa_tgt, placement, colab_name } = requestParameters(
     document
   )
   const attributes = [
-    `mc=${mc || ''}`,
     `referer=${encodeURI(document.referrer)}`,
     `language=${language}`,
     `landing_page=${landingPage}`
@@ -78,5 +77,5 @@ export default document => {
     attributes.push(`colab_name=${encodeURIComponent(colab_name)}`)
   }
 
-  return `/internal/pixel?${attributes.join('&')}`
+  return `/attribution/pixel?${attributes.join('&')}`
 }

--- a/src/requestParameters.js
+++ b/src/requestParameters.js
@@ -15,7 +15,6 @@ export default function requestParameters (document) {
   const search = document.location.search.substring(1)
   const landing = encodeURI(path)
   const locale = document.querySelector('html').lang.split('-')[0]
-  const mc = findPropertyInParams(search, 'mc')
   const gclid = findPropertyInParams(search, 'gclid')
   const aclid = findPropertyInParams(search, 'aclid')
   const fbclid = findPropertyInParams(search, 'fbclid')
@@ -42,7 +41,6 @@ export default function requestParameters (document) {
   return {
     language: locale,
     landingPage: landing,
-    mc,
     gclid,
     aclid,
     fbclid,

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,7 +23,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz"
   integrity sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==
 
-"@babel/core@^7.0.0", "@babel/core@^7.0.0-0", "@babel/core@^7.11.6", "@babel/core@^7.12.3":
+"@babel/core@^7.11.6", "@babel/core@^7.12.3":
   version "7.24.7"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz"
   integrity sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==
@@ -570,12 +570,7 @@ acorn@^3.0.4:
   resolved "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
   integrity sha512-OLUyIIZ7mF5oaAUT1w0TFqQS81q3saT46x8t7ukpPjMNk+nbs4ZHhs7ToV8EWnLYLepjETXd4XaCE4uxkMeqUw==
 
-acorn@^4.0.3:
-  version "4.0.13"
-  resolved "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
-  integrity sha512-fu2ygVGuMmlzG8ZeRJ0bvR41nsAkxxhbyk8bZ1SS521Z7vmgJFTQQlfz/Mp/nJexGBz+v8sC9bM6+lNgskt4Ug==
-
-acorn@^4.0.4:
+acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
   integrity sha512-fu2ygVGuMmlzG8ZeRJ0bvR41nsAkxxhbyk8bZ1SS521Z7vmgJFTQQlfz/Mp/nJexGBz+v8sC9bM6+lNgskt4Ug==
@@ -585,12 +580,7 @@ acorn@^5.0.0, acorn@^5.5.0:
   resolved "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
-ajv-keywords@^1.0.0:
-  version "1.5.1"
-  resolved "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz"
-  integrity sha512-vuBv+fm2s6cqUyey2A7qYcvsik+GMDJsw8BARP2sDE76cqmaZVarsvHf7Vx6VJ0Xk8gLl+u3MoAPf6gKzJefeA==
-
-ajv-keywords@^1.1.1:
+ajv-keywords@^1.0.0, ajv-keywords@^1.1.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz"
   integrity sha512-vuBv+fm2s6cqUyey2A7qYcvsik+GMDJsw8BARP2sDE76cqmaZVarsvHf7Vx6VJ0Xk8gLl+u3MoAPf6gKzJefeA==
@@ -600,7 +590,7 @@ ajv-keywords@^2.1.0:
   resolved "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz"
   integrity sha512-ZFztHzVRdGLAzJmpUT9LNFLe1YiVOEylcaNpEutM26PVTCtOD919IMfD01CgbRouB42Dd9atjx1HseC15DgOZA==
 
-ajv@^4.7.0, ajv@>=4.10.0:
+ajv@^4.7.0, ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
   integrity sha512-I/bSHSNEcFFqXLf91nchoNB9D1Kie3QKcWdchYUaoIg1+1bdWDkdfdlvdIOJbi9U8xR0y+MWc5D+won9v95WlQ==
@@ -608,15 +598,7 @@ ajv@^4.7.0, ajv@>=4.10.0:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^4.9.1:
-  version "4.11.8"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
-  integrity sha512-I/bSHSNEcFFqXLf91nchoNB9D1Kie3QKcWdchYUaoIg1+1bdWDkdfdlvdIOJbi9U8xR0y+MWc5D+won9v95WlQ==
-  dependencies:
-    co "^4.6.0"
-    json-stable-stringify "^1.0.1"
-
-ajv@^5.0.0, ajv@^5.2.3, ajv@^5.3.0:
+ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz"
   integrity sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==
@@ -640,17 +622,7 @@ amdefine@>=0.0.4:
   resolved "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
   integrity sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==
 
-ansi-escapes@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
-  integrity sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw==
-
-ansi-escapes@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
-  integrity sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw==
-
-ansi-escapes@^1.4.0:
+ansi-escapes@^1.0.0, ansi-escapes@^1.1.0, ansi-escapes@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
   integrity sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw==
@@ -862,20 +834,15 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
+assert-plus@1.0.0, assert-plus@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+  integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
+
 assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
   integrity sha512-u1L0ZLywRziOVjUhRxI0Qg9G+4RnFB9H/Rq40YWn0dieDgO7vAYeJz6jKAO6t/aruzlDFLAPkQTT87e+f8Imaw==
-
-assert-plus@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-  integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
-
-assert-plus@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-  integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
 
 assert@^1.1.1:
   version "1.4.1"
@@ -949,7 +916,7 @@ babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-babel-core@^6.0.0, babel-core@^6.24.1, babel-core@^6.25.0, "babel-core@6 || 7 || ^7.0.0-alpha || ^7.0.0-beta || ^7.0.0-rc":
+babel-core@^6.0.0, babel-core@^6.24.1, babel-core@^6.25.0:
   version "6.25.0"
   resolved "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz"
   integrity sha512-wne6XXFyKIfZSLLXN17Zun5aw8x2WZY5ork2NSa5t0UWGxK2EHsJlPd8W1rQQDgpG0tsvEHNdaqmvygEI7Qmmw==
@@ -974,7 +941,7 @@ babel-core@^6.0.0, babel-core@^6.24.1, babel-core@^6.25.0, "babel-core@6 || 7 ||
     slash "^1.0.0"
     source-map "^0.5.0"
 
-babel-eslint@^7.2.3, "babel-eslint@>= 6.0.0":
+"babel-eslint@>= 6.0.0", babel-eslint@^7.2.3:
   version "7.2.3"
   resolved "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz"
   integrity sha512-i2yKOhjgwUbUrJ8oJm6QqRzltIoFahGNPZ0HF22lUN4H1DW03JQyJm7WSv+I1LURQWjDNhVqFo04acYa07rhOQ==
@@ -1497,6 +1464,13 @@ binary-extensions@^1.0.0:
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz"
   integrity sha512-3WXXKEv/uJx27dQVWm5nZnXAU3FFymNhLPcI9j8G7i0QuyJy+f4ocGHSQs+pae+3FOO51DmDYqgFBhno3MTaiQ==
 
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz"
@@ -1602,7 +1576,7 @@ browserify-zlib@^0.1.4:
   dependencies:
     pako "~0.2.0"
 
-browserslist@^4.22.2, "browserslist@>= 4.21.0":
+browserslist@^4.22.2:
   version "4.23.1"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz"
   integrity sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==
@@ -1612,17 +1586,17 @@ browserslist@^4.22.2, "browserslist@>= 4.21.0":
     node-releases "^2.0.14"
     update-browserslist-db "^1.0.16"
 
-bser@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz"
-  integrity sha512-FozP+z0rEpi3AywbeT1QnOrGFJDbC0986aFDR2NlNLF+/WEYdv/7/qb1FVtla+KBWswkQBOA7okWd+85ThWlCQ==
-  dependencies:
-    node-int64 "^0.4.0"
-
 bser@1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz"
   integrity sha512-kKi2swDowbCsnwsYyJnMkz3N1utuJfnWcvzxVX45nWuumTNEkig97rvLVN60+8OWgAWuJdIyEfTPTZqyPoklwA==
+  dependencies:
+    node-int64 "^0.4.0"
+
+bser@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz"
+  integrity sha512-FozP+z0rEpi3AywbeT1QnOrGFJDbC0986aFDR2NlNLF+/WEYdv/7/qb1FVtla+KBWswkQBOA7okWd+85ThWlCQ==
   dependencies:
     node-int64 "^0.4.0"
 
@@ -1750,25 +1724,7 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0:
-  version "2.4.2"
-  resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
-  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
-
-chalk@^2.1.0:
-  version "2.4.2"
-  resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
-  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
-
-chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1833,14 +1789,7 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz"
   integrity sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==
 
-cli-cursor@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
-  integrity sha512-25tABq090YNKkF6JH7lcwO0zFJTRke4Jcq9iX2nr/Sz0Cjjv4gckmwlW6Ty/aoyFd6z3ysR2hMGC2GFugmBo6A==
-  dependencies:
-    restore-cursor "^1.0.1"
-
-cli-cursor@^1.0.2:
+cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
   integrity sha512-25tABq090YNKkF6JH7lcwO0zFJTRke4Jcq9iX2nr/Sz0Cjjv4gckmwlW6Ty/aoyFd6z3ysR2hMGC2GFugmBo6A==
@@ -1919,15 +1868,15 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
@@ -2083,7 +2032,7 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
 
-"cssom@>= 0.3.2 < 0.4.0", cssom@0.3.x:
+cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz"
   integrity sha512-N72oNABuYrOUdPYkT64J8mvYNxFU35kU4Zer3N69aWz4AylPUlSiS/75J+VMAMz9OFf+TTrN3UBrPbcEegOqtg==
@@ -2174,14 +2123,7 @@ debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.1.0:
-  version "4.3.5"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz"
-  integrity sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==
-  dependencies:
-    ms "2.1.2"
-
-debug@^4.3.1:
+debug@^4.1.0, debug@^4.3.1:
   version "4.3.5"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz"
   integrity sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==
@@ -2343,7 +2285,7 @@ enhanced-resolve@^3.0.0:
     object-assign "^4.0.1"
     tapable "^0.2.5"
 
-errno@^0.1.3, "errno@>=0.1.1 <0.2.0-0":
+"errno@>=0.1.1 <0.2.0-0", errno@^0.1.3:
   version "0.1.4"
   resolved "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz"
   integrity sha512-B6ww/BgkeBIfyIaOKPMW2zteXdAeXSfOTPv6kGhl3luYw4BOTopQ0EjdGFePGdajvBjLQZq12axGLtHnrp+/Pg==
@@ -2461,7 +2403,7 @@ es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
     es6-iterator "2"
     es6-symbol "~3.1"
 
-es6-iterator@^2.0.1, es6-iterator@~2.0.1, es6-iterator@2:
+es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz"
   integrity sha512-6QdxKjEfkAutL86ORbUgbZjfmssn3hfrFZDz5utw2BH9EJWYCVVqn9dN/WvsWSzsZ7Ox/fMrHXexX96fF5vEsw==
@@ -2493,7 +2435,7 @@ es6-set@~0.1.5:
     es6-symbol "3.1.1"
     event-emitter "~0.3.5"
 
-es6-symbol@^3.1, es6-symbol@^3.1.1, es6-symbol@~3.1, es6-symbol@~3.1.1, es6-symbol@3.1.1:
+es6-symbol@3.1.1, es6-symbol@^3.1, es6-symbol@^3.1.1, es6-symbol@~3.1, es6-symbol@~3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
   integrity sha512-exfuQY8UGtn/N+gL1iKkH8fpNd5sJ760nJq6mmZAHldfxMD5kX07lbQuYlspoXsuknXNv9Fb7y2GsPOnQIbxHg==
@@ -2569,7 +2511,7 @@ eslint-module-utils@^2.8.0:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-import@^2.29.1, eslint-plugin-import@>=2.2.0:
+eslint-plugin-import@^2.29.1:
   version "2.29.1"
   resolved "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz"
   integrity sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==
@@ -2592,7 +2534,7 @@ eslint-plugin-import@^2.29.1, eslint-plugin-import@>=2.2.0:
     semver "^6.3.1"
     tsconfig-paths "^3.15.0"
 
-eslint-plugin-node@^5.0.0, eslint-plugin-node@>=4.2.2:
+eslint-plugin-node@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.0.0.tgz"
   integrity sha512-9xERRx9V/8ciUHlTDlz9S4JiTL6Dc5oO+jKTy2mvQpxjhycpYZXzTT1t90IXjf+nAYw6/8sDnZfkeixJHxromA==
@@ -2602,12 +2544,12 @@ eslint-plugin-node@^5.0.0, eslint-plugin-node@>=4.2.2:
     resolve "^1.3.3"
     semver "5.3.0"
 
-eslint-plugin-promise@^3.5.0, eslint-plugin-promise@>=3.5.0:
+eslint-plugin-promise@^3.5.0:
   version "3.5.0"
   resolved "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz"
   integrity sha512-kqXN7i1wfx5j7XuFVzuX4W3XDCEyNDsbd+O5NXWIl+zTSP510rKn2Xk8OO6JhM1ivXbkse0tQf6jjSTLS58Prg==
 
-eslint-plugin-standard@^3.0.1, eslint-plugin-standard@>=3.0.0:
+eslint-plugin-standard@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz"
   integrity sha512-JyT7wqVYlaHxnljWMT7CKa0R1QDQqArTi6g8kYnexTHHuK7x3Vg//kCepnoTgdT9x/kDbSluXMhJgjBvgVRLlQ==
@@ -2625,7 +2567,7 @@ eslint-visitor-keys@^1.0.0:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz"
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
-"eslint@^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8", eslint@^4.18.2, "eslint@>= 3.0.0", eslint@>=3.1.0, eslint@>=3.19.0:
+"eslint@>= 3.0.0", eslint@^4.18.2:
   version "4.18.2"
   resolved "https://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz"
   integrity sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==
@@ -2887,15 +2829,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-figures@^1.3.5:
-  version "1.7.0"
-  resolved "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz"
-  integrity sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==
-  dependencies:
-    escape-string-regexp "^1.0.5"
-    object-assign "^4.1.0"
-
-figures@^1.7.0:
+figures@^1.3.5, figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz"
   integrity sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==
@@ -2917,6 +2851,11 @@ file-entry-cache@^2.0.0:
   dependencies:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -3038,6 +2977,14 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@^1.0.0:
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.13.tgz#f325cb0455592428bcf11b383370ef70e3bfcc38"
+  integrity sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==
+  dependencies:
+    bindings "^1.5.0"
+    nan "^2.12.1"
 
 fsevents@^2.3.2:
   version "2.3.3"
@@ -3179,12 +3126,7 @@ glob@~7.0.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^11.0.1:
-  version "11.12.0"
-  resolved "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz"
-  integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
-
-globals@^11.1.0:
+globals@^11.0.1, globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
@@ -3402,17 +3344,17 @@ husky@^0.13.4:
     is-ci "^1.0.9"
     normalize-path "^1.0.0"
 
+iconv-lite@0.4.13:
+  version "0.4.13"
+  resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+  integrity sha512-QwVuTNQv7tXC5mMWFX5N5wGjmybjNBBD8P3BReTkPmipoxTUFgWM2gXNvldHQr6T14DH0Dh6qBVg98iJt7u4mQ==
+
 iconv-lite@^0.4.17:
   version "0.4.24"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
-
-iconv-lite@0.4.13:
-  version "0.4.13"
-  resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
-  integrity sha512-QwVuTNQv7tXC5mMWFX5N5wGjmybjNBBD8P3BReTkPmipoxTUFgWM2gXNvldHQr6T14DH0Dh6qBVg98iJt7u4mQ==
 
 ieee754@^1.1.4:
   version "1.1.8"
@@ -3436,12 +3378,7 @@ indent-string@^2.1.0:
   dependencies:
     repeating "^2.0.0"
 
-indent-string@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/indent-string/-/indent-string-3.1.0.tgz"
-  integrity sha512-dPdzpelBvGyi4vQ3CNhSJ86Dl/IKZ9Ggabsgu22R9jRWTwSKdRKEVZbYM2aIwOBj9vHYqgKQo88l6RW3IDL8qQ==
-
-indent-string@^3.1.0:
+indent-string@^3.0.0, indent-string@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/indent-string/-/indent-string-3.1.0.tgz"
   integrity sha512-dPdzpelBvGyi4vQ3CNhSJ86Dl/IKZ9Ggabsgu22R9jRWTwSKdRKEVZbYM2aIwOBj9vHYqgKQo88l6RW3IDL8qQ==
@@ -3459,7 +3396,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@2:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3823,7 +3760,7 @@ is-weakref@^1.0.2:
   dependencies:
     call-bind "^1.0.2"
 
-isarray@^1.0.0, isarray@~1.0.0, isarray@1.0.0:
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
   integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
@@ -4208,7 +4145,7 @@ jest-resolve-dependencies@^20.0.3:
   dependencies:
     jest-regex-util "^20.0.3"
 
-jest-resolve@*, jest-resolve@^20.0.4:
+jest-resolve@^20.0.4:
   version "20.0.4"
   resolved "https://registry.npmjs.org/jest-resolve/-/jest-resolve-20.0.4.tgz"
   integrity sha512-n/u93CugulXmQ8FcHHGv1kUEFagsbXsJgKLK2G4eAdmawHObAc6DgJtOVp9hgNJOGRU6c6ozdB5nzMO02Fecig==
@@ -4406,31 +4343,6 @@ jsbn@~0.1.0:
   resolved "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
   integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
 
-jsdom@^9.12.0:
-  version "9.12.0"
-  resolved "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz"
-  integrity sha512-Qw4oqNxo4LyzkSqVIyCnEltTc4xV3g1GBaI88AvYTesWzmWHUSoMNmhBjUBa+6ldXIBJS9xoeLNJPfUAykTyxw==
-  dependencies:
-    abab "^1.0.3"
-    acorn "^4.0.4"
-    acorn-globals "^3.1.0"
-    array-equal "^1.0.0"
-    content-type-parser "^1.0.1"
-    cssom ">= 0.3.2 < 0.4.0"
-    cssstyle ">= 0.2.37 < 0.3.0"
-    escodegen "^1.6.1"
-    html-encoding-sniffer "^1.0.1"
-    nwmatcher ">= 1.3.9 < 2.0.0"
-    parse5 "^1.5.1"
-    request "^2.79.0"
-    sax "^1.2.1"
-    symbol-tree "^3.2.1"
-    tough-cookie "^2.3.2"
-    webidl-conversions "^4.0.0"
-    whatwg-encoding "^1.0.1"
-    whatwg-url "^4.3.0"
-    xml-name-validator "^2.0.1"
-
 jsdom@11.0.0:
   version "11.0.0"
   resolved "https://registry.npmjs.org/jsdom/-/jsdom-11.0.0.tgz"
@@ -4450,6 +4362,31 @@ jsdom@11.0.0:
     pn "^1.0.0"
     request "^2.79.0"
     request-promise-native "^1.0.3"
+    sax "^1.2.1"
+    symbol-tree "^3.2.1"
+    tough-cookie "^2.3.2"
+    webidl-conversions "^4.0.0"
+    whatwg-encoding "^1.0.1"
+    whatwg-url "^4.3.0"
+    xml-name-validator "^2.0.1"
+
+jsdom@^9.12.0:
+  version "9.12.0"
+  resolved "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz"
+  integrity sha512-Qw4oqNxo4LyzkSqVIyCnEltTc4xV3g1GBaI88AvYTesWzmWHUSoMNmhBjUBa+6ldXIBJS9xoeLNJPfUAykTyxw==
+  dependencies:
+    abab "^1.0.3"
+    acorn "^4.0.4"
+    acorn-globals "^3.1.0"
+    array-equal "^1.0.0"
+    content-type-parser "^1.0.1"
+    cssom ">= 0.3.2 < 0.4.0"
+    cssstyle ">= 0.2.37 < 0.3.0"
+    escodegen "^1.6.1"
+    html-encoding-sniffer "^1.0.1"
+    nwmatcher ">= 1.3.9 < 2.0.0"
+    parse5 "^1.5.1"
+    request "^2.79.0"
     sax "^1.2.1"
     symbol-tree "^3.2.1"
     tough-cookie "^2.3.2"
@@ -4923,15 +4860,15 @@ minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatc
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
-  version "1.2.8"
-  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
-  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
-
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
   integrity sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==
+
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+  version "1.2.8"
+  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
@@ -4940,17 +4877,12 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   dependencies:
     minimist "0.0.8"
 
-ms@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
-  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
 
-ms@2.1.2:
+ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -4964,6 +4896,11 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz"
   integrity sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==
+
+nan@^2.12.1:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.28.0.tgz#126717fd359d5a03d3edf7c44e6ce9b707fb57f5"
+  integrity sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -5570,15 +5507,15 @@ public-encrypt@^4.0.0:
     parse-asn1 "^5.0.0"
     randombytes "^2.0.1"
 
-punycode@^1.2.4, punycode@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-  integrity sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==
-
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
   integrity sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==
+
+punycode@^1.2.4, punycode@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+  integrity sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==
 
 qs@~6.4.0:
   version "6.4.0"
@@ -5775,7 +5712,7 @@ request-promise-native@^1.0.3:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.0"
 
-request@^2.34, request@^2.79.0:
+request@^2.79.0:
   version "2.81.0"
   resolved "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
   integrity sha512-IZnsR7voF0miGSu29EXPRgPTuEsI/+aibNSBbN1pplrfartF5wDYGADz3iD9vmBVf2r00rckWZf8BtS5kk7Niw==
@@ -5851,6 +5788,11 @@ resolve.exports@^2.0.0:
   resolved "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz"
   integrity sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==
 
+resolve@1.1.7:
+  version "1.1.7"
+  resolved "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+  integrity sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==
+
 resolve@^1.1.6, resolve@^1.20.0, resolve@^1.22.4, resolve@^1.3.2, resolve@^1.3.3:
   version "1.22.8"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz"
@@ -5859,11 +5801,6 @@ resolve@^1.1.6, resolve@^1.20.0, resolve@^1.22.4, resolve@^1.3.2, resolve@^1.3.3
     is-core-module "^2.13.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
-
-resolve@1.1.7:
-  version "1.1.7"
-  resolved "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
-  integrity sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==
 
 restore-cursor@^1.0.1:
   version "1.0.1"
@@ -5965,7 +5902,7 @@ safe-regex-test@^1.0.3:
     es-errors "^1.3.0"
     is-regex "^1.1.4"
 
-safer-buffer@^2.0.2, safer-buffer@^2.1.0, "safer-buffer@>= 2.1.2 < 3", safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -5988,17 +5925,12 @@ sax@^1.2.1:
   resolved "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz"
   integrity sha512-IN2coIooKl8T+3ca83BZTtWUiiYeFRsKCt9NazjxKR4SFXRrbpdR/iwr4B2zCMstVEg+5OFmY/FHh4JJKKS7xA==
 
-semver@^5.3.0, "semver@2 || 3 || 4 || 5", semver@5.3.0:
+"semver@2 || 3 || 4 || 5", semver@5.3.0, semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
   integrity sha512-mfmm3/H9+67MCVix1h+IXTpDwL6710LyHuk7+cWC9T1mE0qz4iHhh6r4hU2wrIT9iTsAAC2XQRvfblL028cpLw==
 
-semver@^6.3.0:
-  version "6.3.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
-  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
-
-semver@^6.3.1:
+semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
@@ -6229,18 +6161,6 @@ stream-to-observable@^0.1.0:
   resolved "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.1.0.tgz"
   integrity sha512-h3mR71JoHxXrKApehgQk1CFbdi2nW9BAVqjPhpPD127H8iz0N61YsCLhJutm+JV0ajNAwPef0kMQsF0Jaz/A6Q==
 
-string_decoder@^0.10.25:
-  version "0.10.31"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-  integrity sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==
-
-string_decoder@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz"
-  integrity sha512-Ma/XSGC8lfDvw75eLjgg/a1nWDButtedmpbbNxH5Ruyr0IhqNXOKbG468VtPosrjhRgNOvgonmY54ZnGMdgJjw==
-  dependencies:
-    safe-buffer "^5.0.1"
-
 string-length@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz"
@@ -6248,16 +6168,7 @@ string-length@^1.0.1:
   dependencies:
     strip-ansi "^3.0.0"
 
-string-width@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
-  integrity sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    strip-ansi "^3.0.0"
-
-string-width@^1.0.2:
+string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
   integrity sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==
@@ -6302,6 +6213,18 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
+string_decoder@^0.10.25:
+  version "0.10.31"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+  integrity sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==
+
+string_decoder@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz"
+  integrity sha512-Ma/XSGC8lfDvw75eLjgg/a1nWDButtedmpbbNxH5Ruyr0IhqNXOKbG468VtPosrjhRgNOvgonmY54ZnGMdgJjw==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 stringstream@~0.0.4:
   version "0.0.6"
   resolved "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz"
@@ -6321,6 +6244,11 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
+strip-bom@3.0.0, strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+  integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
@@ -6328,20 +6256,10 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
-strip-bom@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
-  integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
-
 strip-bom@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz"
   integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
-
-strip-bom@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
-  integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
 
 strip-eof@^1.0.0:
   version "1.0.0"
@@ -6365,14 +6283,7 @@ supports-color@^2.0.0:
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
   integrity sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==
 
-supports-color@^3.1.0:
-  version "3.2.3"
-  resolved "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
-  integrity sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==
-  dependencies:
-    has-flag "^1.0.0"
-
-supports-color@^3.1.2:
+supports-color@^3.1.0, supports-color@^3.1.2:
   version "3.2.3"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
   integrity sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==
@@ -6415,18 +6326,6 @@ symbol-tree@^3.2.1:
   resolved "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz"
   integrity sha512-/2fldTR680SOM4zTfL9mNzf96VYFy2CyVWinf+baRrXAJ4D586mMSorV9Rk5KkK60cUrXASJMojcQsES8PaJMw==
 
-table@^3.7.8:
-  version "3.8.3"
-  resolved "https://registry.npmjs.org/table/-/table-3.8.3.tgz"
-  integrity sha512-RZuzIOtzFbprLCE0AXhkI0Xi42ZJLZhCC+qkwuMLf/Vjz3maWpA8gz1qMdbmNoI9cOROT2Am/DxeRyXenrL11g==
-  dependencies:
-    ajv "^4.7.0"
-    ajv-keywords "^1.0.0"
-    chalk "^1.1.1"
-    lodash "^4.0.0"
-    slice-ansi "0.0.4"
-    string-width "^2.0.0"
-
 table@4.0.2:
   version "4.0.2"
   resolved "https://registry.npmjs.org/table/-/table-4.0.2.tgz"
@@ -6438,6 +6337,18 @@ table@4.0.2:
     lodash "^4.17.4"
     slice-ansi "1.0.0"
     string-width "^2.1.1"
+
+table@^3.7.8:
+  version "3.8.3"
+  resolved "https://registry.npmjs.org/table/-/table-3.8.3.tgz"
+  integrity sha512-RZuzIOtzFbprLCE0AXhkI0Xi42ZJLZhCC+qkwuMLf/Vjz3maWpA8gz1qMdbmNoI9cOROT2Am/DxeRyXenrL11g==
+  dependencies:
+    ajv "^4.7.0"
+    ajv-keywords "^1.0.0"
+    chalk "^1.1.1"
+    lodash "^4.0.0"
+    slice-ansi "0.0.4"
+    string-width "^2.0.0"
 
 tapable@^0.2.5, tapable@~0.2.5:
   version "0.2.6"
@@ -6522,7 +6433,7 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tough-cookie@^2.3.2, tough-cookie@>=2.3.0, tough-cookie@~2.3.0:
+tough-cookie@>=2.3.0, tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   version "2.3.4"
   resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz"
   integrity sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==
@@ -6700,7 +6611,7 @@ util-deprecate@~1.0.1:
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-util@^0.10.3, util@0.10.3:
+util@0.10.3, util@^0.10.3:
   version "0.10.3"
   resolved "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
   integrity sha512-5KiHfsmkqacuKjkRkdV7SsfDJ2EGiPsK92s2MhNSY0craxjTdKTtqKsJaCWp4LW33ZZ0OPUv1WO/TFvNQRiQxQ==
@@ -6780,7 +6691,7 @@ webpack-sources@^0.2.3:
     source-list-map "^1.1.1"
     source-map "~0.5.3"
 
-"webpack@2 || 3", webpack@2.6.1:
+webpack@2.6.1:
   version "2.6.1"
   resolved "https://registry.npmjs.org/webpack/-/webpack-2.6.1.tgz"
   integrity sha512-WkoF1vBKbYYFW4oRNeofwidp14CrzIme8OzDfUK6CEHjCj4zzACAdsTTm23MUd4Ui5bn6OO/GPpc1xBlcKOkRQ==
@@ -6861,15 +6772,15 @@ window-size@0.1.0:
   resolved "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
   integrity sha512-1pTPQDKTdd61ozlKGNCjhNRd+KPmgLSGa3mZTHoOliaGcESD8G1PXhh7c1fgiPjVbNVfgy2Faw4BI8/m0cC8Mg==
 
-wordwrap@^1.0.0, wordwrap@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-  integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
-
 wordwrap@0.0.2:
   version "0.0.2"
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
   integrity sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q==
+
+wordwrap@^1.0.0, wordwrap@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+  integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 worker-farm@^1.3.1:
   version "1.3.1"
@@ -6912,7 +6823,7 @@ xml-name-validator@^2.0.1:
   resolved "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
   integrity sha512-jRKe/iQYMyVJpzPH+3HL97Lgu5HrCfii+qSo+TfjKHtOnvbnvdVfMYrn9Q34YV81M2e5sviJlI6Ko9y+nByzvA==
 
-xtend@^4.0.0, "xtend@>=4.0.0 <4.1.0-0":
+"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0:
   version "4.0.2"
   resolved "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
## Summary
- Removes the legacy `mc` query param and switches the pixel endpoint from `/internal/pixel` to `/attribution/pixel`
- Updates tests and formatting to match the new behavior (lint, format, and jest all pass)

## Test plan
- [x] `npm run lint`
- [x] `npm run jest` (32/32 passing)
- [x] `npm run format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)